### PR TITLE
Handing invalid pin ids

### DIFF
--- a/lib/components/PinterestPinWidget.js
+++ b/lib/components/PinterestPinWidget.js
@@ -471,6 +471,14 @@ var PinterestPinWidget = function (_PinterestBase) {
         key: 'renderPin',
         value: function renderPin() {
             this.logSize = this.props.size === 'small' ? '' : '_' + this.props.size;
+            
+            // Handle non-valid Pin IDs (just return an empty span)
+            if (this.state.pin && this.state.pin.error) {
+                return _react2.default.createElement(
+                    'span'
+                );
+            }
+            
             return _react2.default.createElement(
                 'span',
                 { className: 'pinterest-widget--pin pin-widget--' + this.props.size, style: this.props.style },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "react-pinterest",
-    "version": "1.3.0",
+    "version": "1.3.1",
     "description": "Collection of embeddable Pinterest buttons and widgets",
     "main": "lib/main.js",
     "jsnext:main": "src/main.js",


### PR DESCRIPTION
This returns an empty span if the Pin ID provided refers to a non-existent pin.